### PR TITLE
WIP: Initital proposal for JMarkdown design specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.pytest_cache/
+.ipynb_checkpoints/
+*.egg-info/
+.ropeproject/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "editor.rulers": [88],
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/__pycache__": true,
+        "**/.ipynb_checkpoints": true,
+        "**/pytest_cache": true
+    },
+    "python.pythonPath": "/anaconda/envs/aiida_crystal17/bin/python",
+    "python.formatting.provider": "black"
+}

--- a/imd_poc/definitions.py
+++ b/imd_poc/definitions.py
@@ -1,6 +1,7 @@
 DEFAULT_NB_VERSION = 4
 METADATA_CLASS = "metadata"
 NEW_CELL_CLASS = "new-cell"
-RAW_CLASS = "raw"
+CODE_CELL_CLASS = "code-cell"
+RAW_CELL_CLASS = "raw-cell"
 NB_CELL_CLASS = "nb-cell"
 CELL_NUMBER_ATTR = "cell-number"

--- a/imd_poc/definitions.py
+++ b/imd_poc/definitions.py
@@ -1,0 +1,6 @@
+DEFAULT_NB_VERSION = 4
+METADATA_CLASS = "metadata"
+NEW_CELL_CLASS = "new-cell"
+RAW_CLASS = "raw"
+NB_CELL_CLASS = "nb-cell"
+CELL_NUMBER_ATTR = "cell-number"

--- a/imd_poc/imd2pandoc.py
+++ b/imd_poc/imd2pandoc.py
@@ -6,9 +6,10 @@ import yaml
 from .definitions import (
     METADATA_CLASS,
     NEW_CELL_CLASS,
-    RAW_CLASS,
+    RAW_CELL_CLASS,
     NB_CELL_CLASS,
     CELL_NUMBER_ATTR,
+    CODE_CELL_CLASS,
 )
 
 
@@ -71,7 +72,10 @@ class Imd2PandocAST:
                     found_metadata = True
                 cell_number += 1
 
-            elif isinstance(element, CodeBlock):
+            elif isinstance(element, CodeBlock) and {
+                CODE_CELL_CLASS,
+                RAW_CELL_CLASS,
+            }.intersection(element.classes):
 
                 # handle if a code cell, with no metadata, is before a markdown cell, also with no metadata
                 if cell_content and not found_metadata or len(cell_content) > 1:
@@ -93,11 +97,11 @@ class Imd2PandocAST:
 
                 # add classes
                 attributes = {CELL_NUMBER_ATTR: str(cell_number)}
-                if language_name in element.classes:
+                if CODE_CELL_CLASS in element.classes:
                     classes = [NB_CELL_CLASS, "code"]
                     attributes["kernel"] = kernel_name
                     attributes["language"] = language_name
-                elif RAW_CLASS in element.classes:
+                elif RAW_CELL_CLASS in element.classes:
                     classes = [NB_CELL_CLASS, "raw"]
                 else:
                     classes = [NB_CELL_CLASS, "other"]

--- a/imd_poc/imd2pandoc.py
+++ b/imd_poc/imd2pandoc.py
@@ -1,0 +1,163 @@
+from panflute import CodeBlock, convert_text, Div, Doc, Para, Span
+from panflute.tools import meta2builtin
+from typing import Any, Callable, List, Mapping, TextIO, Tuple, Union
+import yaml
+
+from .definitions import (
+    METADATA_CLASS,
+    NEW_CELL_CLASS,
+    RAW_CLASS,
+    NB_CELL_CLASS,
+    CELL_NUMBER_ATTR,
+)
+
+
+class Imd2PandocAST:
+    def __call__(self, path: Union[str, TextIO]) -> Doc:
+        return self.parse(path)
+
+    def insert_missing_meta(self, content):
+        """In-place insertion of missing metadata."""
+        missing_meta = CodeBlock("{}", classes=[METADATA_CLASS])
+        content.insert(0, missing_meta)
+
+    def parse(self, path: Union[str, TextIO]) -> Doc:
+        """Parse the document."""
+
+        # read document to pandoc AST
+        doc = file_to_doc(path)
+
+        # retrieve metadata
+        doc_metadata = meta2builtin(doc.metadata)
+        language_name = doc_metadata.get("language_info", {}).get("name", "python")
+        kernel_name = doc_metadata.get("kernelspec", {}).get("name", "python3")
+
+        # setup variables
+        doc_content = []
+        cell_content = []
+        found_metadata = False
+        cell_number = 1
+
+        for element in doc.content:
+            is_new_cell_span = False
+            if isinstance(element, Para) and element.content:
+                if (
+                    isinstance(element.content[0], Span)
+                    and NEW_CELL_CLASS in element.content[0].classes
+                ):
+                    is_new_cell_span = True
+            if (
+                isinstance(element, CodeBlock)
+                and METADATA_CLASS in element.classes
+                or is_new_cell_span
+            ):
+                if not found_metadata:
+                    # add missing metadata element to previous cell
+                    self.insert_missing_meta(cell_content)
+                # save previous cell
+                doc_content.append(
+                    Div(
+                        *cell_content,
+                        attributes={CELL_NUMBER_ATTR: str(cell_number)},
+                        classes=[NB_CELL_CLASS, "markdown"],
+                    )
+                )
+                # start a new cell
+                if isinstance(element, Para):
+                    cell_content = []
+                    found_metadata = False
+                else:
+                    cell_content = [element]
+                    found_metadata = True
+                cell_number += 1
+
+            elif isinstance(element, CodeBlock):
+
+                # handle if a code cell, with no metadata, is before a markdown cell, also with no metadata
+                if cell_content and not found_metadata or len(cell_content) > 1:
+                    if not found_metadata:
+                        self.insert_missing_meta(cell_content)
+                    doc_content.append(
+                        Div(
+                            *cell_content,
+                            attributes={CELL_NUMBER_ATTR: str(cell_number)},
+                            classes=[NB_CELL_CLASS, "markdown"],
+                        )
+                    )
+                    cell_number += 1
+                    cell_content = []
+                    self.insert_missing_meta(cell_content)
+                elif not found_metadata:
+                    self.insert_missing_meta(cell_content)
+                cell_content.append(element)
+
+                # add classes
+                attributes = {CELL_NUMBER_ATTR: str(cell_number)}
+                if language_name in element.classes:
+                    classes = [NB_CELL_CLASS, "code"]
+                    attributes["kernel"] = kernel_name
+                    attributes["language"] = language_name
+                elif RAW_CLASS in element.classes:
+                    classes = [NB_CELL_CLASS, "raw"]
+                else:
+                    classes = [NB_CELL_CLASS, "other"]
+
+                doc_content.append(
+                    Div(*cell_content, attributes=attributes, classes=classes)
+                )
+                # start a new cell
+                cell_number += 1
+                cell_content = []
+                found_metadata = False
+            else:
+                cell_content.append(element)
+
+        # deal with any remaining cell_content
+        if cell_content:
+            if not found_metadata:
+                # add missing metadata element to previous cell
+                self.insert_missing_meta(cell_content)
+            # save previous cell
+            doc_content.append(
+                Div(
+                    *cell_content,
+                    attributes={CELL_NUMBER_ATTR: str(cell_number)},
+                    classes=[NB_CELL_CLASS, "markdown"],
+                )
+            )
+
+        doc.content = doc_content
+
+        return doc
+
+
+def doc_to_str(doc: Doc, fmt: str, extra_args: List[str] = (), standalone: bool = True):
+    """Convert pandoc AST to str."""
+    return (
+        convert_text(
+            doc,
+            input_format="panflute",
+            output_format=fmt,
+            standalone=standalone,
+            extra_args=extra_args or [],
+        ).rstrip()
+        + "\n"
+    )
+
+
+def file_to_doc(
+    path: Union[str, TextIO],
+    input_format: str = "markdown",
+    extra_args: List[str] = (),
+    standalone: bool = True,
+):
+    """Read document to pandoc AST."""
+    with open(path) as handle:
+        doc = convert_text(
+            handle.read(),
+            input_format=input_format,
+            standalone=standalone,
+            extra_args=extra_args or [],
+        )
+    return doc
+

--- a/imd_poc/nb2imd.py
+++ b/imd_poc/nb2imd.py
@@ -3,7 +3,13 @@ from nbformat.notebooknode import NotebookNode
 from typing import Any, Callable, Mapping, TextIO, Tuple, Union
 import yaml
 
-from .definitions import DEFAULT_NB_VERSION, METADATA_CLASS, NEW_CELL_CLASS, RAW_CLASS
+from .definitions import (
+    CODE_CELL_CLASS,
+    DEFAULT_NB_VERSION,
+    METADATA_CLASS,
+    NEW_CELL_CLASS,
+    RAW_CELL_CLASS,
+)
 
 
 def mapping_to_dict(
@@ -44,7 +50,7 @@ def parse_nb2imd(path: Union[str, TextIO]) -> str:
     last_cell_type = None
 
     for cell in nb.cells:
-        
+
         # output cell metadata
         if cell.metadata:
             output_string += f"```{METADATA_CLASS}\n"
@@ -60,12 +66,12 @@ def parse_nb2imd(path: Union[str, TextIO]) -> str:
             output_string += cell.source.rstrip() + "\n\n"
 
         if cell.cell_type == "code":
-            output_string += f"```{code_language}\n"
+            output_string += f"```{{.{code_language} .{CODE_CELL_CLASS}}}\n"
             output_string += cell.source.rstrip() + "\n"
             output_string += "```\n\n"
 
         if cell.cell_type == "raw":
-            output_string += f"```{RAW_CLASS}\n"
+            output_string += f"```{RAW_CELL_CLASS}\n"
             output_string += cell.source.rstrip() + "\n"
             output_string += "```\n\n"
 

--- a/imd_poc/nb2imd.py
+++ b/imd_poc/nb2imd.py
@@ -1,0 +1,74 @@
+import nbformat
+from nbformat.notebooknode import NotebookNode
+from typing import Any, Callable, Mapping, TextIO, Tuple, Union
+import yaml
+
+from .definitions import DEFAULT_NB_VERSION, METADATA_CLASS, NEW_CELL_CLASS, RAW_CLASS
+
+
+def mapping_to_dict(
+    obj: Any, strip_keys: list = (), leaf_func: Union[Callable, None] = None
+) -> dict:
+    """Recursively convert mappable objects to dicts, including in lists and tuples.
+
+    :param list[str] strip_keys: list of keys to strip from the output
+    :param leaf_func: a function to apply to leaf values
+
+    """
+
+    if isinstance(obj, Mapping):
+        return {
+            k: mapping_to_dict(obj[k], strip_keys, leaf_func)
+            for k in sorted(obj.keys())
+            if k not in strip_keys
+        }
+    elif isinstance(obj, (list, tuple)):
+        return [mapping_to_dict(i, strip_keys, leaf_func) for i in obj]
+    elif leaf_func is not None:
+        return leaf_func(obj)
+    else:
+        return obj
+
+
+def parse_nb2imd(path: Union[str, TextIO]) -> str:
+    """Parse notebook to the IMarkdown format."""
+    nb = nbformat.read(path, as_version=DEFAULT_NB_VERSION)  # type: NotebookNode
+
+    output_string = "---\n"
+    output_string += yaml.safe_dump(
+        mapping_to_dict(nb.metadata), default_flow_style=False
+    )
+    output_string += "---\n\n"
+
+    code_language = nb.metadata.language_info.name
+    last_cell_type = None
+
+    for cell in nb.cells:
+        
+        # output cell metadata
+        if cell.metadata:
+            output_string += f"```{METADATA_CLASS}\n"
+            output_string += yaml.safe_dump(
+                mapping_to_dict(cell.metadata), default_flow_style=False
+            )
+            output_string += "```\n\n"
+        elif cell.cell_type == "markdown" and last_cell_type == "markdown":
+            # separate cells that do not have metadata in a more concise way
+            output_string += f"[]{{.{NEW_CELL_CLASS}}}\n\n"
+
+        if cell.cell_type == "markdown":
+            output_string += cell.source.rstrip() + "\n\n"
+
+        if cell.cell_type == "code":
+            output_string += f"```{code_language}\n"
+            output_string += cell.source.rstrip() + "\n"
+            output_string += "```\n\n"
+
+        if cell.cell_type == "raw":
+            output_string += f"```{RAW_CLASS}\n"
+            output_string += cell.source.rstrip() + "\n"
+            output_string += "```\n\n"
+
+        last_cell_type = cell.cell_type
+
+    return output_string.rstrip() + "\n"

--- a/imd_poc/pandoc2html.py
+++ b/imd_poc/pandoc2html.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 import importlib_resources
-from panflute import Doc, Div, Para, RawBlock, Space, Str, Emph
+from panflute import Cite, Doc, Div, Para, RawBlock, RawInline, Space, Str, Emph
 import yaml
 
 from imd_poc.pandoc_exec import exec_code_cells
@@ -10,11 +10,26 @@ from imd_poc.imd2pandoc import doc_to_str
 from imd_poc import resources
 
 
+def process_references(cite: Cite, doc: Doc):
+    """Turn citations into anchors."""
+    if not isinstance(cite, Cite):
+        return None
+    return [
+        RawInline(
+            f'<a href="#{c.id}">{doc.labels[c.id]["type"]} {doc.labels[c.id]["number"]}</a>',
+            format="html",
+        )
+        for c in cite.citations
+    ]
+
+
 def pandoc2html(doc: Doc, execute: bool = True):
     """Convert pandoc to HTML."""
     # execute cells
     if execute:
         exec_code_cells(doc)
+
+    doc.labels = {}
 
     # Apply metadata
     for element in doc.content:
@@ -36,6 +51,23 @@ def pandoc2html(doc: Doc, execute: bool = True):
                     element.content.append(
                         RawBlock(output["data"]["text/html"], format="html")
                     )
+                    if "label" in metadata_imd:
+                        label = RawInline(
+                            (
+                                '<a id="{0}" class="anchor-link" name="#{0}" href="#{0}" '
+                                'title="Permalink to this caption">¶</a>'
+                            ).format(metadata_imd["label"]),
+                            format="html",
+                        )
+                        doc.labels = {
+                            metadata_imd["label"]: {
+                                "type": metadata_imd.get("type", "figure").capitalize(),
+                                "number": len(doc.labels) + 1,
+                            }
+                        }
+
+                    else:
+                        label = Str("")
                     if "caption" in metadata_imd:
                         element.content.append(
                             Div(
@@ -46,10 +78,16 @@ def pandoc2html(doc: Doc, execute: bool = True):
                                         ),
                                         Space,
                                         Str(f"{metadata_imd['caption']}"),
+                                        Space,
+                                        label,
                                     )
                                 )
                             )
                         )
+                    else:
+                        element.content.append(Div(Para(label)))
+
+    doc.walk(process_references, doc=doc)
 
     css = importlib_resources.read_text(resources, "html.css")
     css = f"<style>\n{css}\n</style>"

--- a/imd_poc/pandoc2html.py
+++ b/imd_poc/pandoc2html.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+
+import importlib_resources
+from panflute import Doc, Div, Para, RawBlock, Space, Str, Emph
+import yaml
+
+from imd_poc.pandoc_exec import exec_code_cells
+from imd_poc.imd2pandoc import doc_to_str
+from imd_poc import resources
+
+
+def pandoc2html(doc: Doc, execute: bool = True):
+    """Convert pandoc to HTML."""
+    # execute cells
+    if execute:
+        exec_code_cells(doc)
+
+    # Apply metadata
+    for element in doc.content:
+        if isinstance(element, Div):
+            metadata_block = element.content.pop(0)
+            metadata_imd = yaml.safe_load(metadata_block.text).get("imd", {})
+            if "type" in metadata_imd:
+                element.classes.append(str(metadata_imd["type"]))
+            if "code" in element.classes and len(element.content) > 1:
+                output_block = element.content.pop(1)
+                outputs = yaml.safe_load(output_block.text)
+
+                # use just first output for now
+                output = outputs[0]
+                if (
+                    output["output_type"] == "execute_result"
+                    and "text/html" in output["data"]
+                ):
+                    element.content.append(
+                        RawBlock(output["data"]["text/html"], format="html")
+                    )
+                    if "caption" in metadata_imd:
+                        element.content.append(
+                            Div(
+                                Para(
+                                    Emph(
+                                        Str(
+                                            f"{metadata_imd.get('type', 'figure').capitalize()}:"
+                                        ),
+                                        Space,
+                                        Str(f"{metadata_imd['caption']}"),
+                                    )
+                                )
+                            )
+                        )
+
+    css = importlib_resources.read_text(resources, "html.css")
+    css = f"<style>\n{css}\n</style>"
+
+    _, filepath = tempfile.mkstemp()
+    with open(filepath, "w") as handle:
+        handle.write(css)
+    try:
+        string = doc_to_str(doc, "html", extra_args=[f"--include-in-header={filepath}"])
+    finally:
+        os.remove(filepath)
+
+    return string

--- a/imd_poc/pandoc2html.py
+++ b/imd_poc/pandoc2html.py
@@ -30,6 +30,7 @@ def pandoc2html(doc: Doc, execute: bool = True):
         exec_code_cells(doc)
 
     doc.labels = {}
+    num_elements = {}
 
     # Apply metadata
     for element in doc.content:
@@ -48,6 +49,9 @@ def pandoc2html(doc: Doc, execute: bool = True):
                     output["output_type"] == "execute_result"
                     and "text/html" in output["data"]
                 ):
+                    el_type = str(metadata_imd.get('type', 'other')).capitalize()
+                    num_elements.setdefault(el_type, 0)
+                    num_elements[el_type] += 1
                     element.content.append(
                         RawBlock(output["data"]["text/html"], format="html")
                     )
@@ -59,11 +63,9 @@ def pandoc2html(doc: Doc, execute: bool = True):
                             ).format(metadata_imd["label"]),
                             format="html",
                         )
-                        doc.labels = {
-                            metadata_imd["label"]: {
-                                "type": metadata_imd.get("type", "figure").capitalize(),
-                                "number": len(doc.labels) + 1,
-                            }
+                        doc.labels[metadata_imd["label"]] = {
+                            "type": el_type,
+                            "number": num_elements[el_type],
                         }
 
                     else:
@@ -74,7 +76,7 @@ def pandoc2html(doc: Doc, execute: bool = True):
                                 Para(
                                     Emph(
                                         Str(
-                                            f"{metadata_imd.get('type', 'figure').capitalize()}:"
+                                            f"{el_type} {num_elements[el_type]}:"
                                         ),
                                         Space,
                                         Str(f"{metadata_imd['caption']}"),

--- a/imd_poc/pandoc_exec.py
+++ b/imd_poc/pandoc_exec.py
@@ -1,0 +1,100 @@
+from contextlib import contextmanager
+
+from nbconvert.preprocessors.execute import (
+    ExecutePreprocessor,
+    CellExecutionComplete,
+    Empty,
+)
+from panflute import Doc, Div, CodeBlock
+from panflute.tools import meta2builtin
+import yaml
+
+from .definitions import NB_CELL_CLASS, CELL_NUMBER_ATTR
+from imd_poc.nb2imd import mapping_to_dict
+
+
+class SourceExecuter(ExecutePreprocessor):
+    """This is a first stab at an executor that runs directly on source code."""
+
+    @contextmanager
+    def setup_preprocessor(self):
+        self._display_id_map = {}
+        self.widget_state = {}
+        self.widget_buffers = {}
+        self.km, self.kc = self.start_new_kernel(cwd=None)
+        try:
+            yield self.km, self.kc
+        finally:
+            self.kc.stop_channels()
+            self.km.shutdown_kernel(now=self.shutdown_kernel == "immediate")
+            delattr(self, "km")
+            delattr(self, "kc")
+
+    def run_cell(self, source, cell_index=None):
+        parent_msg_id = self.kc.execute(source)
+        self.log.debug("Executing cell:\n%s", source)
+        exec_reply = self._wait_for_reply(parent_msg_id)
+        outputs = []
+        self.clear_before_next_output = False
+
+        while True:
+            try:
+                msg = self.kc.iopub_channel.get_msg(timeout=self.iopub_timeout)
+            except Empty:
+                self.log.warning("Timeout waiting for IOPub output")
+                if self.raise_on_iopub_timeout:
+                    raise RuntimeError("Timeout waiting for IOPub output")
+                else:
+                    break
+            if msg["parent_header"].get("msg_id") != parent_msg_id:
+                # not an output from our execution
+                continue
+            # Will raise CellExecutionComplete when completed
+            try:
+                self.process_message(msg, outputs, cell_index)
+            except CellExecutionComplete:
+                break
+
+        return exec_reply, outputs
+
+    def process_message(self, msg, outputs, cell_index):
+        msg_type = msg["msg_type"]
+        self.log.debug("msg_type: %s", msg_type)
+        content = msg["content"]
+        self.log.debug("content: %s", content)
+        display_id = content.get("transient", {}).get("display_id", None)
+        if display_id and msg_type in {
+            "execute_result",
+            "display_data",
+            "update_display_data",
+        }:
+            self._update_display_id(display_id, msg)
+        if msg_type == "status":
+            if content["execution_state"] == "idle":
+                raise CellExecutionComplete()
+        elif msg_type.startswith("comm"):
+            self.handle_comm_msg(outputs, msg, cell_index)
+        # Check for remaining messages we don't process
+        elif msg_type not in ["execute_input", "update_display_data"]:
+            # Assign output as our processed "result"
+            return self.output(outputs, msg, display_id, cell_index)
+
+
+def exec_code_cells(doc: Doc):
+    """Execute a code cells, in a document that has been created via ```Imd2PandocAST```."""
+    doc_metadata = meta2builtin(doc.metadata)
+    kernel_name = doc_metadata.get("kernelspec", {}).get("name", "python3")
+    executer = SourceExecuter(kernel_name=kernel_name)
+    with executer.setup_preprocessor():
+        for element in doc.content:
+            if isinstance(element, Div) and {NB_CELL_CLASS, "code"}.issubset(
+                element.classes
+            ) and element.attributes.get("kernel", None) == kernel_name:
+                code_block = element.content[1]
+                cell_number = int(element.attributes[CELL_NUMBER_ATTR])
+                exec_reply, outputs = executer.run_cell(
+                    code_block.text, cell_number
+                )
+                element.content.append(
+                    CodeBlock(yaml.safe_dump(mapping_to_dict(outputs)), classes=["yaml", "outputs"])
+                )

--- a/imd_poc/resources/html.css
+++ b/imd_poc/resources/html.css
@@ -1,0 +1,13 @@
+div.nb-cell.code {
+    clear: both;
+}
+div.nb-cell.code div.sourceCode {
+    outline-color: black;
+    outline-style: solid;
+    display: inline-block;
+}
+
+div.nb-cell.markdown.note {
+    background-color: rgb(114, 183, 196);
+    display: inline-block;
+}

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setup(
     name="imd-poc",
     author="Chris Sewell",
     packages=find_packages(),
-    install_requires=["nbformat", "pyyaml", "panflute", "importlib_resources"],
+    install_requires=["nbformat", "nbconvert", "pyyaml", "panflute", "importlib_resources"],
     extras_require={"testing": ["pytest", "pytest-regressions", "pandas"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="imd-poc",
+    author="Chris Sewell",
+    packages=find_packages(),
+    install_requires=["nbformat", "pyyaml", "panflute", "importlib_resources"],
+    extras_require={"testing": ["pytest", "pytest-regressions", "pandas"]},
+)

--- a/tests/imd_test.ipynb
+++ b/tests/imd_test.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# IMarkdown Test Input\n",
+    "\n",
+    "This is some markdown, with **bold** and *italic* text."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "imd": {
+     "fillcolor": "blue",
+     "type": "note"
+    }
+   },
+   "source": [
+    "This is a note."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is markdown after a note"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I've just been run :)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = 1\n",
+    "print(\"I've just been run :)\")\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next code cell has metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "imd": {
+     "caption": "This is a pandas DataFrame.",
+     "label": "tbl:pandas",
+     "type": "table"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   0\n",
+       "0  1\n",
+       "1  2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pandas import DataFrame\n",
+    "DataFrame([1, 2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below is a raw cell."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/latex"
+   },
+   "source": [
+    "I'm a \\textbf{LaTeX} cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Final markdown cell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/imd_test.ipynb
+++ b/tests/imd_test.ipynb
@@ -61,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next code cell has metadata."
+    "The next code cell has metadata, with a label referencing @tbl:pandas."
    ]
   },
   {

--- a/tests/test_imd2pandoc.py
+++ b/tests/test_imd2pandoc.py
@@ -1,0 +1,13 @@
+import os
+
+from imd_poc.imd2pandoc import Imd2PandocAST, doc_to_str
+
+DIRPATH = os.path.realpath(os.path.dirname(__file__))
+
+
+def test_imd2pandoc(file_regression):
+
+    parser = Imd2PandocAST()
+    doc = parser(os.path.join(DIRPATH, "test_nb2imd", "test_nb2imd.md"))
+    file_regression.check(doc_to_str(doc, "markdown"), extension=".md")
+

--- a/tests/test_imd2pandoc/test_imd2pandoc.md
+++ b/tests/test_imd2pandoc/test_imd2pandoc.md
@@ -1,0 +1,110 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: '.py'
+  mimetype: 'text/x-python'
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: '3.6.7'
+widgets:
+  application/vnd.jupyter.widget-state+json:
+    state: {}
+    version_major: 2
+    version_minor: 0
+---
+
+::: {.nb-cell .markdown cell-number="1"}
+``` {.metadata}
+{}
+```
+
+IMarkdown Test Input
+====================
+
+This is some markdown, with **bold** and *italic* text.
+:::
+
+::: {.nb-cell .markdown cell-number="2"}
+``` {.metadata}
+imd:
+  fillcolor: blue
+  type: note
+```
+
+This is a note.
+:::
+
+::: {.nb-cell .markdown cell-number="3"}
+``` {.metadata}
+{}
+```
+
+This is markdown after a note
+:::
+
+::: {.nb-cell .code cell-number="4" kernel="python3" language="python"}
+``` {.metadata}
+{}
+```
+
+``` {.python}
+a = 1
+print("I've just been run :)")
+a
+```
+:::
+
+::: {.nb-cell .markdown cell-number="5"}
+``` {.metadata}
+{}
+```
+
+The next code cell has metadata.
+:::
+
+::: {.nb-cell .code cell-number="6" kernel="python3" language="python"}
+``` {.metadata}
+imd:
+  caption: This is a pandas DataFrame.
+  label: tbl:pandas
+  type: table
+```
+
+``` {.python}
+from pandas import DataFrame
+DataFrame([1, 2])
+```
+:::
+
+::: {.nb-cell .markdown cell-number="7"}
+``` {.metadata}
+{}
+```
+
+Below is a raw cell.
+:::
+
+::: {.nb-cell .raw cell-number="8"}
+``` {.metadata}
+raw_mimetype: text/latex
+```
+
+``` {.raw}
+I'm a \textbf{LaTeX} cell.
+```
+:::
+
+::: {.nb-cell .markdown cell-number="9"}
+``` {.metadata}
+{}
+```
+
+Final markdown cell
+:::

--- a/tests/test_imd2pandoc/test_imd2pandoc.md
+++ b/tests/test_imd2pandoc/test_imd2pandoc.md
@@ -54,7 +54,7 @@ This is markdown after a note
 {}
 ```
 
-``` {.python}
+``` {.python .code-cell}
 a = 1
 print("I've just been run :)")
 a
@@ -77,7 +77,7 @@ imd:
   type: table
 ```
 
-``` {.python}
+``` {.python .code-cell}
 from pandas import DataFrame
 DataFrame([1, 2])
 ```
@@ -96,7 +96,7 @@ Below is a raw cell.
 raw_mimetype: text/latex
 ```
 
-``` {.raw}
+``` {.raw-cell}
 I'm a \textbf{LaTeX} cell.
 ```
 :::

--- a/tests/test_imd2pandoc/test_imd2pandoc.md
+++ b/tests/test_imd2pandoc/test_imd2pandoc.md
@@ -66,7 +66,7 @@ a
 {}
 ```
 
-The next code cell has metadata.
+The next code cell has metadata, with a label referencing @tbl:pandas.
 :::
 
 ::: {.nb-cell .code cell-number="6" kernel="python3" language="python"}

--- a/tests/test_nb2imd.py
+++ b/tests/test_nb2imd.py
@@ -1,0 +1,12 @@
+import os
+
+from imd_poc.nb2imd import parse_nb2imd
+
+DIRPATH = os.path.realpath(os.path.dirname(__file__))
+
+
+def test_nb2imd(file_regression):
+    with open(os.path.join(DIRPATH, "imd_test.ipynb")) as handle:
+        output = parse_nb2imd(handle)
+
+    file_regression.check(output, extension=".md")

--- a/tests/test_nb2imd/test_nb2imd.md
+++ b/tests/test_nb2imd/test_nb2imd.md
@@ -24,7 +24,7 @@ widgets:
 
 This is some markdown, with **bold** and *italic* text.
 
-```{.metadata .yaml}
+```metadata
 imd:
   fillcolor: blue
   type: note
@@ -54,10 +54,6 @@ imd:
 ```{.python .code-cell}
 from pandas import DataFrame
 DataFrame([1, 2])
-```
-
-```{.javascript}
-let a = 1;
 ```
 
 Below is a raw cell.

--- a/tests/test_nb2imd/test_nb2imd.md
+++ b/tests/test_nb2imd/test_nb2imd.md
@@ -1,0 +1,69 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.6.7
+widgets:
+  application/vnd.jupyter.widget-state+json:
+    state: {}
+    version_major: 2
+    version_minor: 0
+---
+
+# IMarkdown Test Input
+
+This is some markdown, with **bold** and *italic* text.
+
+```metadata
+imd:
+  fillcolor: blue
+  type: note
+```
+
+This is a note.
+
+[]{.new-cell}
+
+This is markdown after a note
+
+```python
+a = 1
+print("I've just been run :)")
+a
+```
+
+The next code cell has metadata.
+
+```metadata
+imd:
+  caption: This is a pandas DataFrame.
+  label: tbl:pandas
+  type: table
+```
+
+```python
+from pandas import DataFrame
+DataFrame([1, 2])
+```
+
+Below is a raw cell.
+
+```metadata
+raw_mimetype: text/latex
+```
+
+```raw
+I'm a \textbf{LaTeX} cell.
+```
+
+Final markdown cell

--- a/tests/test_nb2imd/test_nb2imd.md
+++ b/tests/test_nb2imd/test_nb2imd.md
@@ -24,7 +24,7 @@ widgets:
 
 This is some markdown, with **bold** and *italic* text.
 
-```metadata
+```{.metadata .yaml}
 imd:
   fillcolor: blue
   type: note
@@ -36,7 +36,7 @@ This is a note.
 
 This is markdown after a note
 
-```python
+```{.python .code-cell}
 a = 1
 print("I've just been run :)")
 a
@@ -51,9 +51,13 @@ imd:
   type: table
 ```
 
-```python
+```{.python .code-cell}
 from pandas import DataFrame
 DataFrame([1, 2])
+```
+
+```{.javascript}
+let a = 1;
 ```
 
 Below is a raw cell.
@@ -62,7 +66,7 @@ Below is a raw cell.
 raw_mimetype: text/latex
 ```
 
-```raw
+```raw-cell
 I'm a \textbf{LaTeX} cell.
 ```
 

--- a/tests/test_nb2imd/test_nb2imd.md
+++ b/tests/test_nb2imd/test_nb2imd.md
@@ -42,7 +42,7 @@ print("I've just been run :)")
 a
 ```
 
-The next code cell has metadata.
+The next code cell has metadata, with a label referencing @tbl:pandas.
 
 ```metadata
 imd:

--- a/tests/test_pandoc2html.py
+++ b/tests/test_pandoc2html.py
@@ -1,0 +1,13 @@
+import os
+
+from imd_poc.imd2pandoc import doc_to_str, file_to_doc
+from imd_poc.pandoc2html import pandoc2html
+
+DIRPATH = os.path.realpath(os.path.dirname(__file__))
+
+
+def test_pandoc2html(file_regression):
+
+    doc = file_to_doc(os.path.join(DIRPATH, "test_imd2pandoc", "test_imd2pandoc.md"))
+    file_regression.check(pandoc2html(doc), extension=".html")
+

--- a/tests/test_pandoc2html/test_pandoc2html.html
+++ b/tests/test_pandoc2html/test_pandoc2html.html
@@ -112,7 +112,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <span id="cb1-3"><a href="#cb1-3"></a>a</span></code></pre></div>
 </div>
 <div class="nb-cell markdown" data-cell-number="5">
-<p>The next code cell has metadata.</p>
+<p>The next code cell has metadata, with a label referencing <a href="#tbl:pandas">Table 1</a>.</p>
 </div>
 <div class="nb-cell code table" data-cell-number="6" data-kernel="python3" data-language="python">
 <div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1"></a><span class="im">from</span> pandas <span class="im">import</span> DataFrame</span>
@@ -151,7 +151,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </table>
 </div>
 <div>
-<p><em>Table: This is a pandas DataFrame.</em></p>
+<p><em>Table: This is a pandas DataFrame. <a id="tbl:pandas" class="anchor-link" name="#tbl:pandas" href="#tbl:pandas" title="Permalink to this caption">¶</a></em></p>
 </div>
 </div>
 <div class="nb-cell markdown" data-cell-number="7">

--- a/tests/test_pandoc2html/test_pandoc2html.html
+++ b/tests/test_pandoc2html/test_pandoc2html.html
@@ -107,7 +107,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>This is markdown after a note</p>
 </div>
 <div class="nb-cell code" data-cell-number="4" data-kernel="python3" data-language="python">
-<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1"></a>a <span class="op">=</span> <span class="dv">1</span></span>
+<div class="sourceCode" id="cb1"><pre class="sourceCode python code-cell"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1"></a>a <span class="op">=</span> <span class="dv">1</span></span>
 <span id="cb1-2"><a href="#cb1-2"></a><span class="bu">print</span>(<span class="st">&quot;I&#39;ve just been run :)&quot;</span>)</span>
 <span id="cb1-3"><a href="#cb1-3"></a>a</span></code></pre></div>
 </div>
@@ -115,7 +115,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>The next code cell has metadata, with a label referencing <a href="#tbl:pandas">Table 1</a>.</p>
 </div>
 <div class="nb-cell code table" data-cell-number="6" data-kernel="python3" data-language="python">
-<div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1"></a><span class="im">from</span> pandas <span class="im">import</span> DataFrame</span>
+<div class="sourceCode" id="cb2"><pre class="sourceCode python code-cell"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1"></a><span class="im">from</span> pandas <span class="im">import</span> DataFrame</span>
 <span id="cb2-2"><a href="#cb2-2"></a>DataFrame([<span class="dv">1</span>, <span class="dv">2</span>])</span></code></pre></div>
 <div>
 <style scoped>
@@ -158,7 +158,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>Below is a raw cell.</p>
 </div>
 <div class="nb-cell raw" data-cell-number="8">
-<pre class="raw"><code>I&#39;m a \textbf{LaTeX} cell.</code></pre>
+<pre class="raw-cell"><code>I&#39;m a \textbf{LaTeX} cell.</code></pre>
 </div>
 <div class="nb-cell markdown" data-cell-number="9">
 <p>Final markdown cell</p>

--- a/tests/test_pandoc2html/test_pandoc2html.html
+++ b/tests/test_pandoc2html/test_pandoc2html.html
@@ -151,7 +151,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </table>
 </div>
 <div>
-<p><em>Table: This is a pandas DataFrame. <a id="tbl:pandas" class="anchor-link" name="#tbl:pandas" href="#tbl:pandas" title="Permalink to this caption">¶</a></em></p>
+<p><em>Table 1: This is a pandas DataFrame. <a id="tbl:pandas" class="anchor-link" name="#tbl:pandas" href="#tbl:pandas" title="Permalink to this caption">¶</a></em></p>
 </div>
 </div>
 <div class="nb-cell markdown" data-cell-number="7">

--- a/tests/test_pandoc2html/test_pandoc2html.html
+++ b/tests/test_pandoc2html/test_pandoc2html.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Untitled</title>
+  <style>
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <style>
+code.sourceCode > span { display: inline-block; line-height: 1.25; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+  <style>
+  div.nb-cell.code {
+      clear: both;
+  }
+  div.nb-cell.code div.sourceCode {
+      outline-color: black;
+      outline-style: solid;
+      display: inline-block;
+  }
+  
+  div.nb-cell.markdown.note {
+      background-color: rgb(114, 183, 196);
+      display: inline-block;
+  }
+  </style>
+</head>
+<body>
+<div class="nb-cell markdown" data-cell-number="1">
+<h1 id="imarkdown-test-input">IMarkdown Test Input</h1>
+<p>This is some markdown, with <strong>bold</strong> and <em>italic</em> text.</p>
+</div>
+<div class="nb-cell markdown note" data-cell-number="2">
+<p>This is a note.</p>
+</div>
+<div class="nb-cell markdown" data-cell-number="3">
+<p>This is markdown after a note</p>
+</div>
+<div class="nb-cell code" data-cell-number="4" data-kernel="python3" data-language="python">
+<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1"></a>a <span class="op">=</span> <span class="dv">1</span></span>
+<span id="cb1-2"><a href="#cb1-2"></a><span class="bu">print</span>(<span class="st">&quot;I&#39;ve just been run :)&quot;</span>)</span>
+<span id="cb1-3"><a href="#cb1-3"></a>a</span></code></pre></div>
+</div>
+<div class="nb-cell markdown" data-cell-number="5">
+<p>The next code cell has metadata.</p>
+</div>
+<div class="nb-cell code table" data-cell-number="6" data-kernel="python3" data-language="python">
+<div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1"></a><span class="im">from</span> pandas <span class="im">import</span> DataFrame</span>
+<span id="cb2-2"><a href="#cb2-2"></a>DataFrame([<span class="dv">1</span>, <span class="dv">2</span>])</span></code></pre></div>
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>0</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>2</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+<div>
+<p><em>Table: This is a pandas DataFrame.</em></p>
+</div>
+</div>
+<div class="nb-cell markdown" data-cell-number="7">
+<p>Below is a raw cell.</p>
+</div>
+<div class="nb-cell raw" data-cell-number="8">
+<pre class="raw"><code>I&#39;m a \textbf{LaTeX} cell.</code></pre>
+</div>
+<div class="nb-cell markdown" data-cell-number="9">
+<p>Final markdown cell</p>
+</div>
+</body>
+</html>

--- a/tests/test_pandoc_exec.py
+++ b/tests/test_pandoc_exec.py
@@ -1,0 +1,14 @@
+import os
+
+from imd_poc.imd2pandoc import doc_to_str, file_to_doc
+from imd_poc.pandoc_exec import exec_code_cells
+
+DIRPATH = os.path.realpath(os.path.dirname(__file__))
+
+
+def test_pandoc_exec(file_regression):
+
+    doc = file_to_doc(os.path.join(DIRPATH, "test_imd2pandoc", "test_imd2pandoc.md"))
+    exec_code_cells(doc)
+    file_regression.check(doc_to_str(doc, "markdown"), extension=".md")
+

--- a/tests/test_pandoc_exec/test_pandoc_exec.md
+++ b/tests/test_pandoc_exec/test_pandoc_exec.md
@@ -76,7 +76,7 @@ a
 {}
 ```
 
-The next code cell has metadata.
+The next code cell has metadata, with a label referencing @tbl:pandas.
 :::
 
 ::: {.nb-cell .code cell-number="6" kernel="python3" language="python"}

--- a/tests/test_pandoc_exec/test_pandoc_exec.md
+++ b/tests/test_pandoc_exec/test_pandoc_exec.md
@@ -54,7 +54,7 @@ This is markdown after a note
 {}
 ```
 
-``` {.python}
+``` {.python .code-cell}
 a = 1
 print("I've just been run :)")
 a
@@ -87,7 +87,7 @@ imd:
   type: table
 ```
 
-``` {.python}
+``` {.python .code-cell}
 from pandas import DataFrame
 DataFrame([1, 2])
 ```
@@ -124,7 +124,7 @@ Below is a raw cell.
 raw_mimetype: text/latex
 ```
 
-``` {.raw}
+``` {.raw-cell}
 I'm a \textbf{LaTeX} cell.
 ```
 :::

--- a/tests/test_pandoc_exec/test_pandoc_exec.md
+++ b/tests/test_pandoc_exec/test_pandoc_exec.md
@@ -1,0 +1,138 @@
+---
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: '.py'
+  mimetype: 'text/x-python'
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: '3.6.7'
+widgets:
+  application/vnd.jupyter.widget-state+json:
+    state: {}
+    version_major: 2
+    version_minor: 0
+---
+
+::: {.nb-cell .markdown cell-number="1"}
+``` {.metadata}
+{}
+```
+
+IMarkdown Test Input
+====================
+
+This is some markdown, with **bold** and *italic* text.
+:::
+
+::: {.nb-cell .markdown cell-number="2"}
+``` {.metadata}
+imd:
+  fillcolor: blue
+  type: note
+```
+
+This is a note.
+:::
+
+::: {.nb-cell .markdown cell-number="3"}
+``` {.metadata}
+{}
+```
+
+This is markdown after a note
+:::
+
+::: {.nb-cell .code cell-number="4" kernel="python3" language="python"}
+``` {.metadata}
+{}
+```
+
+``` {.python}
+a = 1
+print("I've just been run :)")
+a
+```
+
+``` {.yaml .outputs}
+- {name: stdout, output_type: stream, text: 'I''ve just been run :)
+
+    '}
+- data: {text/plain: '1'}
+  execution_count: 1
+  metadata: {}
+  output_type: execute_result
+```
+:::
+
+::: {.nb-cell .markdown cell-number="5"}
+``` {.metadata}
+{}
+```
+
+The next code cell has metadata.
+:::
+
+::: {.nb-cell .code cell-number="6" kernel="python3" language="python"}
+``` {.metadata}
+imd:
+  caption: This is a pandas DataFrame.
+  label: tbl:pandas
+  type: table
+```
+
+``` {.python}
+from pandas import DataFrame
+DataFrame([1, 2])
+```
+
+``` {.yaml .outputs}
+- data: {text/html: "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type\
+      \ {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n\
+      \        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align:\
+      \ right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n\
+      \    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>0</th>\n\
+      \    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n\
+      \    </tr>\n    <tr>\n      <th>1</th>\n      <td>2</td>\n    </tr>\n  </tbody>\n\
+      </table>\n</div>", text/plain: '   0
+
+      0  1
+
+      1  2'}
+  execution_count: 2
+  metadata: {}
+  output_type: execute_result
+```
+:::
+
+::: {.nb-cell .markdown cell-number="7"}
+``` {.metadata}
+{}
+```
+
+Below is a raw cell.
+:::
+
+::: {.nb-cell .raw cell-number="8"}
+``` {.metadata}
+raw_mimetype: text/latex
+```
+
+``` {.raw}
+I'm a \textbf{LaTeX} cell.
+```
+:::
+
+::: {.nb-cell .markdown cell-number="9"}
+``` {.metadata}
+{}
+```
+
+Final markdown cell
+:::


### PR DESCRIPTION
Following discussion with @choldgraf @jstac and @mmcky, and based on my experience developing [IPyPublish](ipypublish.readthedocs.io), this PR presents an initial design proposal for a JMarkdown (or IMarkdown) design specification.

# Aim

Have a pure text representation of a Jupyter Notebooks, that can be used to create technical/scientific documents. In particular, for conversion to PDF (*via* TeX) and HTML.

# Key Design Goals

For me the key design goals are that it should:
 
- Support key syntax features, required to produce a technical/scientific document:
  - Standard text markup (bold, italic, etc), and block elements (headers, lists, etc)
  - Math
  - Internal labelling and referencing of figure, tables and equations, including those output from code-cells.
  - Referencing of citations, from a bibtex file(s)
  - Referencing of acronyms/definitions would also be desirable, like I have implemented in [sphinx_ext_bibgloss](https://ipypublish.readthedocs.io/en/latest/sphinx_ext_bibgloss.html)
  - Optional formatting of notebook cells and code cell outputs, *via* cell metadata.
- Be easy to read/use/adopt by users
- Be easy to do round trip conversions with a Notebook, e.g.*via* [jupytext](https://jupytext.readthedocs.io)
- Be easy to parse into and manipulate with a document converter, e.g. [pandoc](https://pandoc.org/)
- Be easy to write an [LSP](https://en.wikipedia.org/wiki/Language_Server_Protocol) extension for, to provide cross-editor language support. Note LSP is supported by VS Code, PyCharm, Atom, Sublime, Emacs and Vim, and is currently being implemented in jupyterlab/jupyterlab#2163. A good example of what an LSP can provide, can be seen in [LaTex-Workshop](https://github.com/James-Yu/LaTeX-Workshop), including:
  - General Markdown syntax highlighting, validation and error highlighting
  - Autocompletion of internal references and ‘jump-to-definition’
  - Autocompletion of citations (by linking to a bibtex file) and hover preview of citation metadata
  - Hover previews of LaTex Math
  - Metadata validation, autocompletion, and error highlighting
  - Common snippets insertion

# Implementation Considerations

To support the syntax features, the three main options are: LaTeX, RST and Markdown.
LaTeX supports all of these syntaxes, however, the drawbacks are that (a) it is not intrinsically supported by Jupyter Notebooks, (b) It is not as easy to convert to HTML etc, (c) It's not as user-friendly as Markdown. (a) and (c) also apply to RST, so that leaves us with Markdown.

[RMarkdown](https://rmarkdown.rstudio.com) would then be the next natural consideration, however, this also has some issues:

- It doesn't have a comprehensive design specification. A good example of this is the [CommonMark-Spec](https://github.com/commonmark/commonmark-spec).
- It doesn't intrinsically support markdown/raw cell metadata
- The code cell metadata format (```` ```{`python a=1, b="c"}````), isn't 'official' pandoc syntax (so isn't automatically handled by it), and isn't ideal for usability/readability or parsing.
- It doesn't have first-class support labelling, referencing, etc. (second-class support is provided by [Bookdown](https://bookdown.org/))
- Its pretty closely tied to RStudio and Knitr

This is where JMarkdown comes in. It is similar to RMarkdown, but:

1. Stores metadata for all cells in YAML `metadata` code blocks
2. Will have a comprehensive design specification, that can be used by parsers and LSP, including JSON schema for notebook and cell level metadata (like what is implemented in IPyPublish's [document schema](https://ipypublish.readthedocs.io/en/latest/metadata_doc_schema.html) and [cell schema](https://ipypublish.readthedocs.io/en/latest/metadata_cell_schema.html)).
3. Will eventually provide first-class support for *output agnostic* labelling, referencing, etc, probably through an amalgamation of the (similar) syntaxes derived in [bookdown](https://bookdown.org/yihui/bookdown/) and [IPyPublish](https://ipypublish.readthedocs.io/en/latest/markdown_cells.html).

Also, where possible, the syntax will use the basic Pandoc Markdown elements, and keep boilerplate elements to a minimum.

# Proof of Concept Implementation

In this PR I have created a small python package, as a proof-of-concept for:

- Conversion from a Notebook
- Parsing to Pandoc AST
- Processing of the AST, including code cell execution.
- Converting to HTML

## Conversion from a Notebook

The initial notebook is [imd_test.ipynb](https://github.com/chrisjsewell/meta/blob/imarkdown/tests/imd_test.ipynb). With [imd_poc.nb2imd.parse_nb2imd](https://github.com/chrisjsewell/meta/blob/9d03afcff5a9173c496dd4ce09c8ae553d7f35f3/imd_poc/nb2imd.py#L33), I then parse this  notebook to [test_nb2imd.md](https://raw.githubusercontent.com/chrisjsewell/meta/imarkdown/tests/test_nb2imd/test_nb2imd.md) (and the [preview format](https://github.com/chrisjsewell/meta/blob/imarkdown/tests/test_nb2imd/test_nb2imd.md)), which demonstrates the basic format of JMarkdown. Note:

- Metadata are stored in code blocks, with the identifier `metadata`
- Raw cells are stored in code blocks, with the identifier `raw-cell`
- Code cells are stored in code blocks, with the identifiers `code-cell` and the language, obtained from the notebook metadata. Unfortunately, GitHub only syntax highlights the shortcut form; ```` ```python````, which I originally used, but this could be an issue if someone wanted to write python code in a markdown cell, so  ```` ```{.python .code-cell}```` is more robust.
- Metadata is not required for every cell. If the metadata is empty, then a block will not be created. 
- if a Markdown cell with no metadata follows another metadata cell then a Pandoc `Span` is inserted with the `new-cell` class: `[]{.new-cell}`. This ensures a parser can identify the start of all new cells (in the current jupytext RMarkdown converter, multiple markdown cells are merged, during the round-trip conversion).

TODO handling cell attachments

## Parsing to Pandoc AST

In [imd_poc.imd2pandoc](https://github.com/chrisjsewell/meta/blob/9aaddd9cc63094c75f42f663e347efa7d2ac2692/imd_poc/imd2pandoc.py), `test_nb2imd.md` is parsed directly into pandoc AST (using [panflute](http://scorreia.com/software/panflute)), then some intital processing is done, to convert the document to a more 'computationally friendly' format (inserting missing metadata, wrapping metadata & cell content in divs, and numbering cells). Converting back to Markdown, we obtain [test_imd2pandoc.md](https://github.com/chrisjsewell/meta/blob/imarkdown/tests/test_imd2pandoc/test_imd2pandoc.md).

## Code cell execution and output to HTML

In [imd_poc.pandoc_exec](https://github.com/chrisjsewell/meta/blob/b95b162b4c8deca099ae47641ae6e731801ebaa7/imd_poc/pandoc_exec.py), I iterate through the pandoc AST,  and execute all the code cells, saving the outputs as YAML. Converting back to Markdown we get: [test_pandoc_exec.md](https://github.com/chrisjsewell/meta/blob/imarkdown/tests/test_pandoc_exec/test_pandoc_exec.md).

In [imd_poc.pandoc2html](https://github.com/chrisjsewell/meta/blob/b95b162b4c8deca099ae47641ae6e731801ebaa7/imd_poc/pandoc2html.py), I build on this to process references and create a basic HTML document: [test_pandoc2html.html](https://github.com/chrisjsewell/meta/blob/imarkdown/tests/test_pandoc2html/test_pandoc2html.html)

![image](https://user-images.githubusercontent.com/2997570/68838871-69153200-06b7-11ea-994b-e1c169b76cbd.png)

Note how we've now utilized the metadata to colour a note block, place a numbered caption under the generated pandas table and added an anchor link to it, and turned the reference into a hyperlink with the same name as the table caption.

You'll also note that I haven't used the [nbconvert](https://nbconvert.readthedocs.io/en/latest/) conversion mechanism. My approach has a number of benefits:

1. You don't need to convert the document back to a notebook before conversion. You might want to use jupytext to sync with it though, if you wanted to access pre-computed code cell outputs.
2. You only need to run pandoc once on the entire document. This is a big win, because with nbconvert, you have to call it separately for every markdown cell, which is not particularly efficient, and makes it more difficult to deal with *document wide* aspects, like figure numbering.
3. In my opinion the nbconvert process is overly complex, because of (a) the Traitlets configuration (which they are already discussing replacing), and (b) the Jinja templates. Writing Jinja templates is essentially like writing in a completely different programming language. This might be fine, if the language editor support was anywhere close to the level of python, which it isn't. Because of this, it makes them tedious to write, test and maintain.

Finally, to create HTML, it is better to use Sphinx (as I already do in IPyPublish).
This would either be via the creation of an intermediate RST representation, or you might even be able to convert the pandoc AST directly to the [docutils](http://docutils.sourceforge.net/) AST (which is what Sphinx uses at a lower level).

I think that's about it for now!
